### PR TITLE
Check for same permission as in controller

### DIFF
--- a/Menu.php
+++ b/Menu.php
@@ -21,7 +21,7 @@ class Menu extends \Piwik\Plugin\Menu
 	
     public function configureAdminMenu(MenuAdmin $menu)
     {
-    		if (Piwik::isUserHasSomeAdminAccess()){
+    		if (Piwik::hasUserSuperUserAccess()){
     			$menu->addSystemItem(
     				Piwik::translate('BotTracker_BotTracker'), 
     				array('module' => 'BotTracker', 'action' => 'config'), 


### PR DESCRIPTION
Currently the menu item is shown to admins, but when viewing the page it is restricted to super users only. To not result in an error, the same access checks should be used.