### PR TITLE
Assure that useragent length limit is kept for extra stats table

### DIFF
--- a/BotTracker.php
+++ b/BotTracker.php
@@ -125,7 +125,8 @@ class BotTracker extends \Piwik\Plugin
 			if ($result['extra_stats'] > 0){
 				$query = "INSERT INTO `".Common::prefixTable('bot_db_stat')."` 
 					(idsite, botid, page, visit_timestamp, useragent) VALUES (?,?,?,?,?)";
-				$params = array($idSite,$botId,$currentUrl,$currentTimestamp,$ua);
+				// max length of useragent can be 100 Bytes
+				$params = array($idSite,$botId,$currentUrl,$currentTimestamp,substr($ua,0,100));
 				$db->query($query,$params);
 			}
 		}


### PR DESCRIPTION
Similar to the URL length, also the user agent string length is limited to 100 bytes/characters. But it is currently not assured that this limit is kept before the database query is done.

There are user agents with much longer strings, e.g. "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1 (compatible; Baiduspider-render/2.0; +http://www.baidu.com/search/spider.html" with 211 characters. Similar to the URL, such strings are now truncated before the database query is done. This must not be done earlier, since the $ua variable is used for user agent ID estimation, where the identifying pattern must not be truncated.

This is a quick fix, while there might be smarter solutions, like increasing the allowed size of the useragent field, or removing specific parts from the string, which are known to be less relevant. E.g. with this solution, the above example would not contain the identifying "Baiduspider-render" anymore.