### PR TITLE
Fix plugin does not work when used in Matomo for WordPress

### DIFF
--- a/BotTracker.php
+++ b/BotTracker.php
@@ -17,9 +17,8 @@ use Piwik\Db;
 use Piwik\Plugins\SitesManager\API as APISitesManager;
 use Piwik\Piwik;
 use Piwik\Tracker;
+use Piwik\Plugin;
 use Piwik\Plugins\BotTracker\API as BotTrackerAPI;
-
-require_once PIWIK_INCLUDE_PATH . '/plugins/BotTracker/functions.php';
 
 class BotTracker extends \Piwik\Plugin
 {	
@@ -31,6 +30,12 @@ class BotTracker extends \Piwik\Plugin
 		{
 			botDb_close($this->botDb);
 		}
+	}
+	
+	public function postLoad()
+	{
+		$dir = Plugin\Manager::getPluginDirectory('BotTracker');
+		require_once $dir . '/functions.php';
 	}
 	
 	public function install()


### PR DESCRIPTION
We have a report from a user in https://wordpress.org/support/topic/fatal-error-when-trying-to-activate-bot-tracker/ who wanted to use this plugin in Matomo for WordPress. However, it resulted in an error because when `BotTracker.php` is loaded as a WordPress plugin, then `PIWIK_INCLUDE_PATH` might not exist. In the plugins where we used a `functions.php` we instead changed it to load the functions.php a bit later (in this time every time the plugin is being loaded on every request). It will also use the new method `getPluginDirectory` which we added in one of the last releases in Matomo 3.X so this way it supports Matomo's feature to customise the plugins directory.