### PR TITLE
Fix plugin does not work when used in Matomo for WordPress

### DIFF
--- a/API.php
+++ b/API.php
@@ -20,10 +20,6 @@ use Piwik\Site;
 use Piwik\Date;
 use Piwik\Piwik;
 
-/**
- * @see plugins/BotTracker/functions.php
- */
-require_once PIWIK_INCLUDE_PATH . '/plugins/BotTracker/functions.php';
 
 /**
  * @package Piwik_BotTracker


### PR DESCRIPTION
follow up from  #83

The plugin now failed in the API.php where it shouldn't be needed to load the functions.php as it's already done when loading the plugin.

Sorry about that and about not including it in the other PR. Should have checked.